### PR TITLE
Use of 1st person in RFC 33

### DIFF
--- a/files/drafts/RFC-0033/RFC-0033.md
+++ b/files/drafts/RFC-0033/RFC-0033.md
@@ -24,7 +24,7 @@ Cadastral maps in combination with the adjoined information in the registers oft
 
 # Definition
 
-In this chapter, we will attempt to define the cadastre in the context of the Time Machine Organization (TMO). First, we must point out that we will use the term cadastre by abuse of language in the sense of cadastral map. We will call pre-cadastres the textual cadastral registers that predominated before the appearance of the cadastral map. Such pre-cadastres, however, are not the subject of this RFC. The definition of the cadastral object should allow to coordinate research and processing efforts and to develop common and generic solutions for the analysis, extraction and valorization of these documents. Thus, in the context of the Time Machine, by cadastre (or cadaster), we imply the following:
+This chapter defines the concept of cadastre in the context of the Time Machine Organization (TMO). First, we must point out that we will use the term cadastre by abuse of language in the sense of cadastral map. We will call pre-cadastres the textual cadastral registers that predominated before the appearance of the cadastral map. Such pre-cadastres, however, are not the subject of this RFC. The definition of the cadastral object should allow to coordinate research and processing efforts and to develop common and generic solutions for the analysis, extraction and valorization of these documents. Thus, in the context of the Time Machine, by cadastre (or cadaster), we imply the following:
  
 > **Cadastre** – A (set of) cartographic document(s), with or without an associated legend, established as a result of topographic surveys and administrative operations, describing the division into parcels and the state of land ownership of a geographical area.
  


### PR DESCRIPTION
RFC should not be written at the first person. This should be corrected on the entire document (and somehow made explicit in the rule writing rules).